### PR TITLE
Grahamj remove date

### DIFF
--- a/markdoc.gemspec
+++ b/markdoc.gemspec
@@ -1,8 +1,10 @@
 require './lib/markdoc/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'markdoc'
   s.version     = Markdoc::VERSION
+  s.date        = Date.today.to_s
   s.summary     = "Markdown to HTML converter with diagrams"
   s.description = "Markdown with support for pseudocode to flowchart and sequence diagram generation"
   s.authors     = ["Lkhagva Ochirkhuyag"]

--- a/markdoc.gemspec
+++ b/markdoc.gemspec
@@ -3,7 +3,6 @@ require './lib/markdoc/version'
 Gem::Specification.new do |s|
   s.name        = 'markdoc'
   s.version     = Markdoc::VERSION
-  s.date        = Date.today.to_s
   s.summary     = "Markdown to HTML converter with diagrams"
   s.description = "Markdown with support for pseudocode to flowchart and sequence diagram generation"
   s.authors     = ["Lkhagva Ochirkhuyag"]


### PR DESCRIPTION
`Date` is no longer included with bundler, and must use `require`.

Without this, running `bundle` commands like `outdated` in ZetaTango will crash, and when it does `bundle` anything is permanently screwed up moving forward.